### PR TITLE
feat: add Super Randonneur award to Annual Awards section

### DIFF
--- a/frontend/src/__tests__/awards/awards.test.ts
+++ b/frontend/src/__tests__/awards/awards.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   checkRrtyYears,
   checkBrevetKm,
+  checkSuperRandonneur,
   checkFourProvinces,
   checkEasterFleche,
   checkFourNations,
@@ -114,6 +115,36 @@ describe("checkBrevetKm", () => {
   it("skips DNF activities", () => {
     const a = makeActivity({ date: "2025-03-15", eventType: "BRM200", distance: 200, dnf: true });
     expect(checkBrevetKm([a]).size).toBe(0);
+  });
+});
+
+// ── Super Randonneur ─────────────────────────────────────────────────────────
+
+describe("checkSuperRandonneur", () => {
+  it("returns empty map when no activities", () => {
+    expect(checkSuperRandonneur([])).toEqual(new Map());
+  });
+
+  it("marks season as not met when missing distances", () => {
+    const activities = [
+      makeActivity({ date: "2025-04-15", eventType: "BRM200", distance: 200 }),
+      makeActivity({ date: "2025-05-15", eventType: "BRM300", distance: 300 }),
+    ];
+    const result = checkSuperRandonneur(activities);
+    expect(result.get("2024-25")?.met).toBe(false);
+    expect(result.get("2024-25")?.distances.size).toBe(2);
+  });
+
+  it("marks season as met when 200, 300, 400, 600 completed", () => {
+    const activities = [
+      makeActivity({ date: "2025-04-15", eventType: "BRM200", distance: 200 }),
+      makeActivity({ date: "2025-05-15", eventType: "BRM300", distance: 300 }),
+      makeActivity({ date: "2025-06-15", eventType: "BRM400", distance: 400 }),
+      makeActivity({ date: "2025-07-15", eventType: "BRM600", distance: 600 }),
+    ];
+    const result = checkSuperRandonneur(activities);
+    expect(result.get("2024-25")?.met).toBe(true);
+    expect(result.get("2024-25")?.distances.size).toBe(4);
   });
 });
 

--- a/frontend/src/awards/awards.ts
+++ b/frontend/src/awards/awards.ts
@@ -87,6 +87,34 @@ export function checkBrevetKm(activities: AwardsActivity[]): Map<string, number>
   return result;
 }
 
+// ── Super Randonneur ──────────────────────────────────────────────────────────
+
+export interface SuperRandonneurStatus {
+  met: boolean;
+  distances: Set<EventType>;
+}
+
+export function checkSuperRandonneur(
+  activities: AwardsActivity[]
+): Map<string, SuperRandonneurStatus> {
+  const result = new Map<string, SuperRandonneurStatus>();
+  const srDistances = ["BRM200", "BRM300", "BRM400", "BRM600"] as const;
+
+  for (const a of activities) {
+    if (!isAwardEligible(a) || !srDistances.includes(a.eventType as any)) continue;
+    const season = activitySeason(a.date);
+    if (!result.has(season)) {
+      result.set(season, { met: false, distances: new Set() });
+    }
+    const status = result.get(season)!;
+    status.distances.add(a.eventType as EventType);
+    if (srDistances.every((d) => status.distances.has(d))) {
+      status.met = true;
+    }
+  }
+  return result;
+}
+
 // ── 4 Provinces ───────────────────────────────────────────────────────────────
 
 const PROVINCES = ["Ulster", "Leinster", "Munster", "Connacht"] as const;

--- a/frontend/src/pages/AwardsPage.tsx
+++ b/frontend/src/pages/AwardsPage.tsx
@@ -5,6 +5,7 @@ import { UnconfirmedRidesNotice } from "../components/UnconfirmedRidesNotice";
 import {
   checkRrtyYears,
   checkBrevetKm,
+  checkSuperRandonneur,
   checkFourProvinces,
   checkEasterFleche,
   checkFourNations,
@@ -107,6 +108,7 @@ export default function AwardsPage() {
 
   const rrtyYears = checkRrtyYears(awards);
   const brevetKm = checkBrevetKm(awards);
+  const superRandonneur = checkSuperRandonneur(awards);
   const fourProvinces = checkFourProvinces(awards);
   const easterFleches = checkEasterFleche(awards);
   const fourNations = checkFourNations(awards);
@@ -171,6 +173,21 @@ export default function AwardsPage() {
       {/* ── Annual Awards ───────────────────────────────────────────── */}
       <section className="space-y-3">
         <SectionHeading>Annual Awards</SectionHeading>
+
+        <AwardRow
+          label="Super Randonneur"
+          description={`Complete a BRM 200, 300, 400, and 600 in the same audax season (Nov–Oct). Total completed: ${[...superRandonneur.values()].filter(s => s.met).length}`}
+        >
+          {allSeasons.filter((s) => superRandonneur.get(s)?.met).length === 0 ? (
+            <span className="text-xs text-gray-400 italic">No completed seasons yet</span>
+          ) : (
+            allSeasons
+              .filter((s) => superRandonneur.get(s)?.met)
+              .map((season) => (
+                <TrophyBadge key={season} label={season} />
+              ))
+          )}
+        </AwardRow>
 
         <AwardRow
           label="RRTY — Randonneur Round The Year"


### PR DESCRIPTION
- Implement checkSuperRandonneur logic to track 200/300/400/600 series per audax season
- Display SR award progress and total completions on the Awards page
- Add unit tests for the new award calculation logic

this fixes #6 