### PR TITLE
fix: treat Northern Ireland as Ireland for award tracking

### DIFF
--- a/frontend/src/__tests__/awards/awards.test.ts
+++ b/frontend/src/__tests__/awards/awards.test.ts
@@ -186,6 +186,22 @@ describe("checkFourProvinces", () => {
     const act = makeActivity({ date: "2025-03-01", startRegion: null });
     expect(checkFourProvinces([act]).size).toBe(0);
   });
+
+  it("counts a Northern Ireland ride as Ulster province", () => {
+    const activities = [
+      makeActivity({ date: "2025-03-01", startRegion: "Leinster" }),
+      makeActivity({ date: "2025-04-01", startRegion: "Munster" }),
+      makeActivity({ date: "2025-05-01", startRegion: "Connacht" }),
+      makeActivity({
+        date: "2025-06-01",
+        startCountry: "United Kingdom",
+        startRegion: "Northern Ireland",
+      }),
+    ];
+    const result = checkFourProvinces(activities);
+    expect(result.get("2024-25")?.met).toBe(true);
+    expect(result.get("2024-25")?.provinces["Ulster"]).toHaveLength(1);
+  });
 });
 
 // ── Easter Flèche ────────────────────────────────────────────────────────────
@@ -267,7 +283,7 @@ describe("checkFourNations", () => {
     expect(checkFourNations(activities).met).toBe(false);
   });
 
-  it("requires start and end in same nation", () => {
+  it("treats a ride crossing Republic/Northern Ireland border as Ireland", () => {
     const crossBorder = makeActivity({
       eventType: "BRM200",
       distance: 200,
@@ -283,7 +299,45 @@ describe("checkFourNations", () => {
       makeNationActivity("BRM400", "Scotland"),
       makeNationActivity("BRM600", "Wales"),
     ];
+    expect(checkFourNations(activities).met).toBe(true);
+  });
+
+  it("does not count a ride crossing Ireland and England border", () => {
+    const crossBorder = makeActivity({
+      eventType: "BRM200",
+      distance: 200,
+      date: "2025-03-01",
+      startCountry: "Ireland",
+      startRegion: "Leinster",
+      endCountry: "United Kingdom",
+      endRegion: "England",
+    });
+    const activities = [
+      crossBorder,
+      makeNationActivity("BRM300", "England"),
+      makeNationActivity("BRM400", "Scotland"),
+      makeNationActivity("BRM600", "Wales"),
+    ];
     expect(checkFourNations(activities).met).toBe(false);
+  });
+
+  it("counts a ride entirely within Northern Ireland as Ireland", () => {
+    const niRide = makeActivity({
+      eventType: "BRM200",
+      distance: 200,
+      date: "2025-03-01",
+      startCountry: "United Kingdom",
+      startRegion: "Northern Ireland",
+      endCountry: "United Kingdom",
+      endRegion: "Northern Ireland",
+    });
+    const activities = [
+      niRide,
+      makeNationActivity("BRM300", "England"),
+      makeNationActivity("BRM400", "Scotland"),
+      makeNationActivity("BRM600", "Wales"),
+    ];
+    expect(checkFourNations(activities).met).toBe(true);
   });
 });
 
@@ -363,6 +417,14 @@ describe("getInternationalRides", () => {
   it("excludes DNF activities", () => {
     const dnfAbroad = makeActivity({ startCountry: "France", dnf: true });
     expect(getInternationalRides([dnfAbroad])).toHaveLength(0);
+  });
+
+  it("does not treat Northern Ireland as international", () => {
+    const niRide = makeActivity({
+      startCountry: "United Kingdom",
+      startRegion: "Northern Ireland",
+    });
+    expect(getInternationalRides([niRide])).toHaveLength(0);
   });
 
   it("sorts by date descending (most recent first)", () => {

--- a/frontend/src/__tests__/geo/geocoder.test.ts
+++ b/frontend/src/__tests__/geo/geocoder.test.ts
@@ -44,10 +44,29 @@ describe("parseNominatimRegion", () => {
     expect(result.region).toBe("Munster");
   });
 
-  it("returns state directly for UK activities", () => {
+  it("returns state directly for UK activities (England/Scotland/Wales)", () => {
     const result = parseNominatimRegion({ country: "United Kingdom", state: "Scotland" });
     expect(result.country).toBe("United Kingdom");
     expect(result.region).toBe("Scotland");
+  });
+
+  it("maps Northern Ireland to Ireland with Ulster province via county", () => {
+    const result = parseNominatimRegion({
+      country: "United Kingdom",
+      state: "Northern Ireland",
+      county: "County Antrim",
+    });
+    expect(result.country).toBe("Ireland");
+    expect(result.region).toBe("Ulster");
+  });
+
+  it("maps Northern Ireland to Ireland/Ulster when county is missing", () => {
+    const result = parseNominatimRegion({
+      country: "United Kingdom",
+      state: "Northern Ireland",
+    });
+    expect(result.country).toBe("Ireland");
+    expect(result.region).toBe("Ulster");
   });
 
   it("returns state for non-IE/UK countries", () => {

--- a/frontend/src/awards/awards.ts
+++ b/frontend/src/awards/awards.ts
@@ -142,6 +142,19 @@ export function checkSuperRandonneur(
   return result;
 }
 
+// ── Ireland normalisation ─────────────────────────────────────────────────────
+// Northern Ireland is part of the UK in geocoding data, but for Irish cycling
+// awards it should be treated as Ireland (province: Ulster).
+function normalizeToIreland(
+  country: string | null,
+  region: string | null
+): { country: string | null; region: string | null } {
+  if (country === "United Kingdom" && region === "Northern Ireland") {
+    return { country: "Ireland", region: "Ulster" };
+  }
+  return { country, region };
+}
+
 // ── 4 Provinces ───────────────────────────────────────────────────────────────
 
 const PROVINCES = ["Ulster", "Leinster", "Munster", "Connacht"] as const;
@@ -156,21 +169,16 @@ export function checkFourProvinces(
 ): Map<string, FourProvincesSeason> {
   const result = new Map<string, FourProvincesSeason>();
 
-  const qualifying = activities.filter(
-    (a) =>
-      isAwardEligible(a) &&
-      a.eventType !== null &&
-      a.distance >= 200 &&
-      a.startRegion !== null &&
-      PROVINCES.includes(a.startRegion as (typeof PROVINCES)[number])
-  );
+  for (const a of activities) {
+    if (!isAwardEligible(a) || a.eventType === null || a.distance < 200) continue;
+    const { region } = normalizeToIreland(a.startCountry, a.startRegion);
+    if (region === null || !PROVINCES.includes(region as (typeof PROVINCES)[number])) continue;
 
-  for (const a of qualifying) {
     const season = activitySeason(a.date);
     if (!result.has(season)) result.set(season, { met: false, provinces: {} });
     const seasonData = result.get(season)!;
-    if (!seasonData.provinces[a.startRegion!]) seasonData.provinces[a.startRegion!] = [];
-    seasonData.provinces[a.startRegion!]!.push(a);
+    if (!seasonData.provinces[region]) seasonData.provinces[region] = [];
+    seasonData.provinces[region]!.push(a);
   }
 
   for (const data of result.values()) {
@@ -285,7 +293,9 @@ export function checkFourNations(activities: AwardsActivity[]): SrNationsResult 
   );
 
   const getNation = (a: AwardsActivity): string | null => {
-    if (a.startCountry === "Ireland" && a.endCountry === "Ireland") return "Ireland";
+    const start = normalizeToIreland(a.startCountry, a.startRegion);
+    const end = normalizeToIreland(a.endCountry, a.endRegion);
+    if (start.country === "Ireland" && end.country === "Ireland") return "Ireland";
     if (
       a.startCountry === "United Kingdom" &&
       a.endCountry === "United Kingdom" &&
@@ -353,7 +363,8 @@ export function getInternationalRides(
         isAwardEligible(a) &&
         a.eventType !== null &&
         (a.isNotableInternational ||
-          (a.startCountry !== null && a.startCountry !== "Ireland"))
+          (a.startCountry !== null &&
+            normalizeToIreland(a.startCountry, a.startRegion).country !== "Ireland"))
     )
     .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
 }

--- a/frontend/src/geo/geocoder.ts
+++ b/frontend/src/geo/geocoder.ts
@@ -42,6 +42,10 @@ export function parseNominatimRegion(address: {
   }
 
   if (country === "United Kingdom") {
+    if (address.state === "Northern Ireland") {
+      const region = address.county ? (countyToProvince(address.county) ?? "Ulster") : "Ulster";
+      return { country: "Ireland", region };
+    }
     return { country, region: address.state ?? null };
   }
 
@@ -94,7 +98,8 @@ export async function geocodeActivities(
       a.startLat !== null &&
       a.eventType !== null &&
       (a.startCountry === null ||
-        (a.startCountry === "Ireland" && a.startRegion === null))
+        (a.startCountry === "Ireland" && a.startRegion === null) ||
+        (a.startCountry === "United Kingdom" && a.startRegion === "Northern Ireland"))
   );
   if (toGeocode.length === 0) return;
 


### PR DESCRIPTION
## Summary

Fixes #7 — rides in Northern Ireland were geocoded as `United Kingdom / Northern Ireland` by Nominatim, causing them to be invisible to the 4 Provinces and 4 Nations awards.

- **`geocoder.ts`**: `parseNominatimRegion` now maps `UK + Northern Ireland` → `country: "Ireland", region: "Ulster"` (using the county→province lookup when available). `geocodeActivities` also queues existing NI activities for re-geocoding.
- **`awards.ts`**: Added `normalizeToIreland()` helper and applied it in `checkFourProvinces`, `checkFourNations`, and `getInternationalRides` so that any stored activities with the old `UK/NI` data are also handled correctly.
- **Tests**: Added coverage for NI → Ulster province, NI counting as Ireland in the 4 Nations award, Republic↔NI cross-border rides counting as Ireland, and NI rides not appearing in international rides.

## Test plan

- [ ] All existing tests pass (192 tests)
- [ ] New geocoder tests: NI → Ireland/Ulster with and without county
- [ ] New awards tests: NI ride counts as Ulster in 4 Provinces, NI ride counts as Ireland in 4 Nations, cross-border Republic/NI ride counts as Ireland, NI ride not shown as international

🤖 Generated with [Claude Code](https://claude.com/claude-code)