### PR TITLE
Fix sync detection, exclude DNFs from season summary, fix Brevet 2000 calculation

### DIFF
--- a/frontend/src/__tests__/awards/awards.test.ts
+++ b/frontend/src/__tests__/awards/awards.test.ts
@@ -459,14 +459,23 @@ describe("getInternationalRides", () => {
 });
 
 describe("checkBrevetKm — award eligibility", () => {
-  it("excludes unconfirmed activities from season km", () => {
+  it("counts auto-distance (unconfirmed) activities — classification source is irrelevant for Brevet 2000/5000", () => {
     const activities = [
       makeActivity({ eventType: "BRM200", distance: 200, date: "2025-06-01", classificationSource: "auto-distance" }),
       makeActivity({ eventType: "BRM200", distance: 200, date: "2025-06-15" }),
     ];
     const result = checkBrevetKm(activities);
     const season = activitySeason("2025-06-01");
-    // Only the confirmed activity should count
+    expect(result.get(season)?.total).toBe(400);
+  });
+
+  it("excludes activities with excludeFromAwards=true", () => {
+    const activities = [
+      makeActivity({ eventType: "BRM200", distance: 200, date: "2025-06-01", excludeFromAwards: true }),
+      makeActivity({ eventType: "BRM200", distance: 200, date: "2025-06-15" }),
+    ];
+    const result = checkBrevetKm(activities);
+    const season = activitySeason("2025-06-01");
     expect(result.get(season)?.total).toBe(200);
   });
 });

--- a/frontend/src/awards/awards.ts
+++ b/frontend/src/awards/awards.ts
@@ -98,7 +98,7 @@ export interface BrevetKmStatus {
 export function checkBrevetKm(activities: AwardsActivity[]): Map<string, BrevetKmStatus> {
   const result = new Map<string, BrevetKmStatus>();
   for (const a of activities) {
-    if (!isAwardEligible(a) || !BREVET_TYPES.includes(a.eventType as EventType)) continue;
+    if (a.dnf || a.excludeFromAwards || !BREVET_TYPES.includes(a.eventType as EventType)) continue;
     const season = activitySeason(a.date);
     if (!result.has(season)) {
       result.set(season, { total: 0, activities: [] });

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { NavLink, Outlet, useLocation } from "react-router-dom";
 import { useAuth } from "../context/AuthContext";
 import { useSyncContext } from "../context/SyncContext";
@@ -15,7 +15,15 @@ const navLinkClass = ({ isActive }: { isActive: boolean }) =>
 
 export default function Layout() {
   const { isAuthenticated, tokens, logout } = useAuth();
-  const { geocoding, cloudSync, sync, fullSync, syncing, checking, pendingCount, progress, rateLimitWait, lastSync } = useSyncContext();
+  const { geocoding, cloudSync, sync, fullSync, syncing, checking, pendingCount, progress, rateLimitWait, lastSync, checkPending } = useSyncContext();
+  const didCheckRef = useRef(false);
+  useEffect(() => {
+    if (!didCheckRef.current) {
+      didCheckRef.current = true;
+      checkPending();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   const hasPending = pendingCount > 0;
   const [showConsentDialog, setShowConsentDialog] = useState(false);
   const [showDisableDialog, setShowDisableDialog] = useState(false);

--- a/frontend/src/pages/YearlySummaryPage.tsx
+++ b/frontend/src/pages/YearlySummaryPage.tsx
@@ -14,7 +14,7 @@ export default function YearlySummaryPage() {
   const activities = useLiveQuery(() => db.activities.toArray());
 
   const audaxActivities = useMemo(
-    () => (activities ?? []).filter((a) => a.eventType !== null),
+    () => (activities ?? []).filter((a) => a.eventType !== null && !a.dnf),
     [activities],
   );
 
@@ -362,6 +362,8 @@ export default function YearlySummaryPage() {
                           <EventTypeBadge
                             eventType={activity.eventType}
                             source={activity.classificationSource}
+                            needsConfirmation={activity.needsConfirmation && !activity.manualOverride}
+                            dnf={activity.dnf}
                           />
                         </span>
                       </td>


### PR DESCRIPTION
## Summary

- **Sync button**: Move `checkPending()` call from `DashboardPage` to `Layout` so pending activity count is checked on every page load, not just the dashboard
- **DNF exclusion from season summary**: Filter out DNF activities from the Audax Season Summary table and stats (rides/km/elevation)
- **DNF badge in season summary**: Pass `dnf` and `needsConfirmation` props to `EventTypeBadge` in `YearlySummaryPage` so DNF indicator renders correctly
- **Brevet 2000/5000 fix**: `checkBrevetKm` was gated on `isAwardEligible` which requires `classificationSource === "auto-name"` — changed to only exclude `dnf` and `excludeFromAwards`, so auto-distance classified activities correctly count toward Brevet 2000/5000 totals

## Test plan

- [ ] Sync button shows pending count when navigating to any page (not just dashboard)
- [ ] DNF activities (e.g. LEL25) no longer appear in Audax Season Summary table or stats
- [ ] Awards page shows Brevet 2000 for all seasons with ≥2000 km of completed brevets
- [ ] All 50 awards unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)