### PR TITLE
Awards page improvements

### DIFF
--- a/frontend/src/pages/AwardsPage.tsx
+++ b/frontend/src/pages/AwardsPage.tsx
@@ -193,7 +193,7 @@ export default function AwardsPage() {
             <div className="flex items-center justify-between">
               <h3 className="text-sm font-semibold text-gray-800">Randonneur 5000</h3>
               {status5000.qualified ? (
-                <span className="rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-800">Qualified ✓</span>
+                <span className="inline-flex items-center gap-1.5 rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-800"><span className="text-base leading-none">🏆</span> Qualified ✓</span>
               ) : (
                 <span className="rounded-full bg-yellow-100 px-2.5 py-0.5 text-xs font-medium text-yellow-800">
                   {Math.round(status5000.totalKm).toLocaleString()} / 5000 km
@@ -211,7 +211,7 @@ export default function AwardsPage() {
             <div className="flex items-center justify-between">
               <h3 className="text-sm font-semibold text-gray-800">Randonneur 10000</h3>
               {status10000.qualified ? (
-                <span className="rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-800">Qualified ✓</span>
+                <span className="inline-flex items-center gap-1.5 rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-800"><span className="text-base leading-none">🏆</span> Qualified ✓</span>
               ) : (
                 <span className="rounded-full bg-yellow-100 px-2.5 py-0.5 text-xs font-medium text-yellow-800">
                   {Math.round(status10000.totalKm).toLocaleString()} / 10000 km
@@ -271,6 +271,17 @@ export default function AwardsPage() {
                   <TrophyBadge key={season} label={`${season} (${Math.round(brevetKm.get(season)!.total)} km)`} activities={brevetKm.get(season)?.activities} />
                 ))
             )}
+            {allSeasons.filter((s) => { const t = brevetKm.get(s)?.total ?? 0; return t > 0 && t < 2000; }).length > 0 && (
+              <div className="w-full mt-1 flex flex-wrap gap-1">
+                {allSeasons
+                  .filter((s) => { const t = brevetKm.get(s)?.total ?? 0; return t > 0 && t < 2000; })
+                  .map((season) => (
+                    <span key={season} className="text-xs text-gray-400 italic">
+                      {season}: {Math.round(brevetKm.get(season)!.total)} km
+                    </span>
+                  ))}
+              </div>
+            )}
           </AwardRow>
 
           <AwardRow
@@ -285,6 +296,17 @@ export default function AwardsPage() {
                 .map((season) => (
                   <TrophyBadge key={season} label={`${season} (${Math.round(brevetKm.get(season)!.total)} km)`} activities={brevetKm.get(season)?.activities} />
                 ))
+            )}
+            {allSeasons.filter((s) => { const t = brevetKm.get(s)?.total ?? 0; return t > 0 && t < 5000; }).length > 0 && (
+              <div className="w-full mt-1 flex flex-wrap gap-1">
+                {allSeasons
+                  .filter((s) => { const t = brevetKm.get(s)?.total ?? 0; return t > 0 && t < 5000; })
+                  .map((season) => (
+                    <span key={season} className="text-xs text-gray-400 italic">
+                      {season}: {Math.round(brevetKm.get(season)!.total)} km
+                    </span>
+                  ))}
+              </div>
             )}
           </AwardRow>
 

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -173,11 +173,14 @@ export default function DashboardPage() {
 
       {/* Expiring events warnings */}
       {(() => {
-        const merged = mergeExpiringEvents(status5000.expiringEvents, status10000.expiringEvents);
+        const r5qualified = status5000.qualified;
+        const r10qualified = status10000.qualified;
+        const merged = mergeExpiringEvents(status5000.expiringEvents, status10000.expiringEvents)
+          .filter((ev) => ev.affects.some((a) => (a === "R5000" && !r5qualified) || (a === "R10000" && !r10qualified)));
         return merged.length > 0 ? (
           <div className="rounded-lg border border-yellow-300 bg-yellow-50 p-4">
             <h3 className="mb-2 text-sm font-semibold text-yellow-800">
-              Critical events expiring within 6 months
+              Critical events expiring within 12 months
             </h3>
             <ul className="space-y-1">
               {merged.map((ev) => (

--- a/frontend/src/pages/QualificationDetailPage.tsx
+++ b/frontend/src/pages/QualificationDetailPage.tsx
@@ -5,13 +5,10 @@ import { UnconfirmedRidesNotice } from "../components/UnconfirmedRidesNotice";
 import {
   checkAcp5000,
   checkAcp10000,
-  findBestWindow,
-  ACP_QUALIFYING_TYPES,
   type QualifyingActivity,
   type Requirement,
   type ExpiringEvent,
 } from "../qualification/tracker";
-import { isAwardEligible } from "../classification/classifier";
 import { ProgressBar } from "../components/ProgressBar";
 import { EventTypeBadge, ClassificationLegend } from "../components/EventTypeBadge";
 import { formatDate } from "../utils/date";
@@ -184,11 +181,10 @@ export default function QualificationDetailPage() {
     ? checkAcp5000(qualActivities)
     : checkAcp10000(qualActivities);
 
-  const eligibleActivities = qualActivities.filter(
-    (a) => isAwardEligible(a) && a.eventType && (ACP_QUALIFYING_TYPES as readonly string[]).includes(a.eventType)
-  );
-
-  const windowActivities = findBestWindow(eligibleActivities, windowYears);
+  // Use the exact window computed by checkAcp5000/checkAcp10000 (uses score-based
+  // window selection that boosts Fleche/PBP-containing windows, unlike findBestWindow
+  // which only maximises km).
+  const windowActivities = status.windowActivities;
 
   // Derive window dates from the activities in the best window
   const windowDates =
@@ -333,7 +329,7 @@ export default function QualificationDetailPage() {
       {status.expiringEvents.length > 0 && (
         <div className="rounded-lg border border-yellow-300 bg-yellow-50 p-4">
           <h3 className="mb-2 text-sm font-semibold text-yellow-800">
-            Events expiring within 6 months
+            Events expiring within 12 months
           </h3>
           <ul className="space-y-1">
             {status.expiringEvents.map((ev: ExpiringEvent) => (

--- a/frontend/src/qualification/tracker.ts
+++ b/frontend/src/qualification/tracker.ts
@@ -56,6 +56,7 @@ export interface Acp5000Status {
   fleche: Requirement;
   distance: DistanceRequirement;
   expiringEvents: ExpiringEvent[];
+  windowActivities: QualifyingActivity[];
 }
 
 export interface Acp10000Status {
@@ -68,6 +69,7 @@ export interface Acp10000Status {
   fleche: Requirement;
   distance: DistanceRequirement;
   expiringEvents: ExpiringEvent[];
+  windowActivities: QualifyingActivity[];
 }
 
 const BRM_DISTANCES: NonNullable<EventType>[] = [
@@ -312,7 +314,7 @@ export function countBrmSeries(activities: QualifyingActivity[]): number {
  * Finds critical expiring events: events that, if they fall out of the
  * rolling window, would cause a currently-met requirement to become unmet.
  *
- * For each event expiring in the next 6 months, we check whether removing
+ * For each event expiring in the next 12 months, we check whether removing
  * it would break a requirement (e.g. losing the only PBP, or dropping
  * from 1 complete BRM series to 0).
  */
@@ -325,16 +327,16 @@ function findExpiringEvents(
   if (windowActivities.length === 0) return [];
 
   const now = new Date();
-  const sixMonthsFromNow = new Date(now);
-  sixMonthsFromNow.setMonth(sixMonthsFromNow.getMonth() + 6);
+  const twelveMonthsFromNow = new Date(now);
+  twelveMonthsFromNow.setMonth(twelveMonthsFromNow.getMonth() + 12);
 
-  // Find events expiring within 6 months
+  // Find events expiring within 12 months
   const expiring: { activity: QualifyingActivity; expiresAt: Date }[] = [];
   for (const a of windowActivities) {
     const activityDate = new Date(a.date);
     const expiresAt = new Date(activityDate);
     expiresAt.setFullYear(expiresAt.getFullYear() + windowYears);
-    if (expiresAt > now && expiresAt <= sixMonthsFromNow) {
+    if (expiresAt > now && expiresAt <= twelveMonthsFromNow) {
       expiring.push({ activity: a, expiresAt });
     }
   }
@@ -512,6 +514,7 @@ export function checkAcp5000(
     fleche,
     distance,
     expiringEvents: findExpiringEvents(windowActivities, 4, 1, "R5000"),
+    windowActivities,
   };
 }
 
@@ -834,5 +837,6 @@ export function checkAcp10000(
     fleche,
     distance,
     expiringEvents: findExpiringEvents(windowActivities, 6, 2, "R10000"),
+    windowActivities,
   };
 }


### PR DESCRIPTION
## Summary

- **Trophy icons on R5000/R10000**: Awards page now shows 🏆 Qualified ✓ badge (matching other award styles) when achieved
- **Brevet 2000/5000 progress display**: Shows per-season km totals for seasons below the threshold, useful for tracking progress
- **Fleche in completion timeline**: Fixed Fleche ride details missing from the R5000/R10000 completion timeline. Root cause: page used `findBestWindow` (max km only) while `checkAcp5000` used `pickBestCandidateWindow` (Fleche-aware scoring), so they could pick different windows. Fix: `checkAcp5000`/`checkAcp10000` now return `windowActivities` in their result, and the page uses that directly
- **12-month expiry window**: Extended "critical events expiring" warning from 6 months to 12 months (dashboard + qualification detail pages)
- **Suppress expiry warnings for qualified awards**: Dashboard no longer shows expiring event warnings for awards already qualified (e.g. R5000 expiry warnings suppressed when R5000 is already qualified)

## Test plan

- [ ] R5000 shows 🏆 on awards page when qualified
- [ ] Brevet 2000/5000 shows in-progress season km below the trophy
- [ ] Fleche ride details appear in R5000 completion timeline
- [ ] Expiry warnings only appear for unqualified awards
- [ ] All 236 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)