### PR TITLE
Hide expiry warning on qualification pages when already qualified

### DIFF
--- a/frontend/src/pages/QualificationDetailPage.tsx
+++ b/frontend/src/pages/QualificationDetailPage.tsx
@@ -309,24 +309,8 @@ export default function QualificationDetailPage() {
         />
       </div>
 
-      {/* Requirements checklist */}
-      <div>
-        <h2 className="mb-3 text-lg font-semibold text-gray-900">
-          Requirements
-        </h2>
-        <div className="space-y-2">
-          {requirements.map((r) => (
-            <RequirementCard
-              key={r.label}
-              label={r.label}
-              requirement={r.requirement}
-            />
-          ))}
-        </div>
-      </div>
-
       {/* Expiring events warning */}
-      {status.expiringEvents.length > 0 && (
+      {!status.qualified && status.expiringEvents.length > 0 && (
         <div className="rounded-lg border border-yellow-300 bg-yellow-50 p-4">
           <h3 className="mb-2 text-sm font-semibold text-yellow-800">
             Events expiring within 12 months
@@ -349,6 +333,22 @@ export default function QualificationDetailPage() {
           </ul>
         </div>
       )}
+
+      {/* Requirements checklist */}
+      <div>
+        <h2 className="mb-3 text-lg font-semibold text-gray-900">
+          Requirements
+        </h2>
+        <div className="space-y-2">
+          {requirements.map((r) => (
+            <RequirementCard
+              key={r.label}
+              label={r.label}
+              requirement={r.requirement}
+            />
+          ))}
+        </div>
+      </div>
 
       {/* Completion timeline */}
       {requirements.some((r) => r.requirement.completedDate) && (


### PR DESCRIPTION
## Summary

- Suppress the "Events expiring within 12 months" warning on `/qualification/5000` and `/qualification/10000` when the award is already qualified — no point warning about expiry when you've already achieved it
- Moved the warning to appear above the requirements checklist (was below it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)