### PR TITLE
fix: remove unused vars causing CI build failure

### DIFF
--- a/frontend/src/__tests__/forms/acpFormGenerator.test.ts
+++ b/frontend/src/__tests__/forms/acpFormGenerator.test.ts
@@ -37,7 +37,7 @@ function makeActivity(overrides: Partial<QualifyingActivity>): QualifyingActivit
 
 describe("buildR5000TemplateData", () => {
   it("fills personal info from profile", () => {
-    const data = buildR5000TemplateData(profile, [], 0);
+    const data = buildR5000TemplateData(profile, []);
     expect(data.lastName).toBe("Murphy");
     expect(data.firstName).toBe("Ciara");
     expect(data.birthDate).toBe("15/03/1985");
@@ -47,7 +47,7 @@ describe("buildR5000TemplateData", () => {
 
   it("formats dates as dd/mm/yyyy", () => {
     const activities = [makeActivity({ eventType: "BRM200", date: "2023-06-15T00:00:00.000Z" })];
-    const data = buildR5000TemplateData(profile, activities, 200);
+    const data = buildR5000TemplateData(profile, activities);
     expect(data.brm200Date).toBe("15/06/2023");
   });
 
@@ -56,7 +56,7 @@ describe("buildR5000TemplateData", () => {
       makeActivity({ stravaId: "1", eventType: "BRM200", name: "BRM 200 Dublin", distance: 200, homologationNumber: "IE-001" }),
       makeActivity({ stravaId: "2", eventType: "BRM300", name: "BRM 300 Cork", distance: 300, homologationNumber: "IE-002", date: "2023-07-01T00:00:00.000Z" }),
     ];
-    const data = buildR5000TemplateData(profile, activities, 500);
+    const data = buildR5000TemplateData(profile, activities);
     expect(data.brm200Name).toBe("BRM 200 Dublin");
     expect(data.brm200Cert).toBe("IE-001");
     expect(data.brm300Name).toBe("BRM 300 Cork");
@@ -64,7 +64,7 @@ describe("buildR5000TemplateData", () => {
   });
 
   it("leaves mandatory slot empty when no matching activity", () => {
-    const data = buildR5000TemplateData(profile, [], 0);
+    const data = buildR5000TemplateData(profile, []);
     expect(data.brm200Date).toBe("");
     expect(data.brm200Name).toBe("");
     expect(data.brm200Cert).toBe("");
@@ -75,14 +75,14 @@ describe("buildR5000TemplateData", () => {
     const activities = [
       makeActivity({ stravaId: "1", eventType: "SR600", name: "Rocky Road SR600", distance: 600, homologationNumber: "SR-001" }),
     ];
-    const data = buildR5000TemplateData(profile, activities, 600);
+    const data = buildR5000TemplateData(profile, activities);
     expect(data.brm600Name).toBe("Rocky Road SR600");
     expect(data.brm600Cert).toBe("SR-001");
   });
 
   it("uses null homologation number as empty string", () => {
     const activities = [makeActivity({ eventType: "BRM200", homologationNumber: null })];
-    const data = buildR5000TemplateData(profile, activities, 200);
+    const data = buildR5000TemplateData(profile, activities);
     expect(data.brm200Cert).toBe("");
   });
 
@@ -91,7 +91,7 @@ describe("buildR5000TemplateData", () => {
       makeActivity({ stravaId: "1", eventType: "BRM200", name: "First BRM200", date: "2023-01-01T00:00:00.000Z" }),
       makeActivity({ stravaId: "2", eventType: "BRM200", name: "Second BRM200", date: "2023-03-01T00:00:00.000Z" }),
     ];
-    const data = buildR5000TemplateData(profile, activities, 400);
+    const data = buildR5000TemplateData(profile, activities);
     expect(data.brm200Name).toBe("First BRM200"); // earliest goes to mandatory slot
     expect(data.brmRides).toHaveLength(1);
     expect(data.brmRides[0].name).toBe("Second BRM200");
@@ -101,7 +101,7 @@ describe("buildR5000TemplateData", () => {
     const activities = [
       makeActivity({ stravaId: "1", eventType: "RM1200+", name: "LEL 1400", distance: 1400 }),
     ];
-    const data = buildR5000TemplateData(profile, activities, 1400);
+    const data = buildR5000TemplateData(profile, activities);
     expect(data.brevet1200Rides).toHaveLength(1);
     expect(data.brevet1200Rides[0].name).toBe("LEL 1400");
   });
@@ -111,7 +111,7 @@ describe("buildR5000TemplateData", () => {
       makeActivity({ stravaId: "1", eventType: "Fleche", name: "Easter Fleche 2022", date: "2022-04-15T00:00:00.000Z" }),
       makeActivity({ stravaId: "2", eventType: "Fleche", name: "Easter Fleche 2023", date: "2023-04-07T00:00:00.000Z" }),
     ];
-    const data = buildR5000TemplateData(profile, activities, 720);
+    const data = buildR5000TemplateData(profile, activities);
     expect(data.flecheName).toBe("Easter Fleche 2022"); // earliest to mandatory
     expect(data.flecheRides).toHaveLength(1);
     expect(data.flecheRides[0].name).toBe("Easter Fleche 2023");
@@ -123,7 +123,7 @@ describe("buildR5000TemplateData", () => {
       makeActivity({ stravaId: "2", date: "2022-06-01T00:00:00.000Z" }),
       makeActivity({ stravaId: "3", date: "2024-01-10T00:00:00.000Z" }),
     ];
-    const data = buildR5000TemplateData(profile, activities, 600);
+    const data = buildR5000TemplateData(profile, activities);
     expect(data.firstEventDate).toBe("01/06/2022");
     expect(data.lastEventDate).toBe("10/01/2024");
   });
@@ -134,7 +134,7 @@ describe("buildR5000TemplateData", () => {
       makeActivity({ stravaId: "1", eventType: "BRM200", distance: 208 }),
       makeActivity({ stravaId: "2", eventType: "BRM300", distance: 305.7, date: "2023-07-01T00:00:00.000Z" }),
     ];
-    const data = buildR5000TemplateData(profile, activities, 99999);
+    const data = buildR5000TemplateData(profile, activities);
     // BRM200 fills mandatory slot (208 km), BRM300 fills mandatory slot (305.7 km)
     // No balance rides needed. Total = 208 + 305.7 = 513.7 → rounded to 514
     expect(data.totalKm).toBe("514 km");

--- a/frontend/src/forms/acpFormGenerator.ts
+++ b/frontend/src/forms/acpFormGenerator.ts
@@ -77,7 +77,6 @@ function slotFields(a: QualifyingActivity | null): { date: string; name: string;
 export function buildR5000TemplateData(
   profile: RiderProfile,
   windowActivities: QualifyingActivity[],
-  totalKm: number,
 ): R5000TemplateData {
   // Pick mandatory slots
   const brm200 = pickSlot(windowActivities, ["BRM200"]);
@@ -177,11 +176,7 @@ export async function generateR5000Form(
   profile: RiderProfile,
   status: Acp5000Status,
 ): Promise<void> {
-  const templateData = buildR5000TemplateData(
-    profile,
-    status.windowActivities,
-    status.totalKm,
-  );
+  const templateData = buildR5000TemplateData(profile, status.windowActivities);
 
   const response = await fetch(r5000TemplateUrl);
   const arrayBuffer = await response.arrayBuffer();

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { getProfile, saveProfile, type RiderProfile } from "../db/profile";
+import { getProfile, saveProfile } from "../db/profile";
 
 const EMPTY_FORM = {
   lastName: "",


### PR DESCRIPTION
## Summary

- Remove unused `totalKm` parameter from `buildR5000TemplateData` (now computes its own total from included activities)
- Remove unused `RiderProfile` type import from `ProfilePage.tsx`
- Update all test call sites to drop the removed parameter

Fixes the TypeScript `TS6133` errors that broke CI on #31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)